### PR TITLE
added sourcemap flag to webpack configuration

### DIFF
--- a/cypress/webpack.config.js
+++ b/cypress/webpack.config.js
@@ -7,5 +7,6 @@ module.exports = {
         use: 'svelte-loader'
       }
     ]
-  }
+  },
+  devtool: 'cheap-module-eval-source-map'
 }


### PR DESCRIPTION
I think for unit testing it always makes sense to have sourcemaps. It took me some time to look up how to do that with webpack, suggest to add it in the sample configuration.