### PR TITLE
feat: add callbacks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ This component adaptor is meant for [Svelte v3](https://svelte.dev/blog/svelte-3
 
 Import your Svelte component and mount using the provided function. Pass [component options](https://svelte.dev/docs#Creating_a_component) and global document options (like a global CSS)
 
+### Props
+
 ```js
 /// <reference types="cypress" />
 import App from '../components/ChainedBalls.svelte'
@@ -158,6 +160,8 @@ describe('SVG animation', () => {
 })
 ```
 
+### Styles
+
 You can use local styles, local CSS file path (relative to the the Cypress project root) or external stylesheets. See [styles example](cypress/components/styles). You can surround the component with HTML and mount the component into the element with ID "here", see [cypress/components/mount-html](cypress/components/mount-html)
 
 ```js
@@ -186,6 +190,27 @@ mount(HelloWorld, props, {
 
 ![Mount HTML example](images/mount-html.png)
 
+### Callbacks
+
+You can listen for messages from the component by supplying an object of callbacks.
+
+```js
+mount(TodoItem, {
+  props: {
+    id: 'todo-id',
+    text: 'write a test',
+    complete: false,
+  },
+  callbacks: {
+    remove: cy.stub().as('remove'),
+    toggle: cy.stub().as('toggle'),
+    'inner-message': cy.stub().as('inner-message'),
+  },
+})
+```
+
+See [cypress/components/callbacks](cypress/components/callbacks).
+
 ## Examples
 
 Svelte components copied from [https://svelte.dev/examples](https://svelte.dev/examples)
@@ -196,6 +221,7 @@ All components and tests are in [cypress/components](cypress/components) folder
 Test | Description
 --- | ---
 [animation](cypress/components/animation) | Chained balls SVG animation
+[callbacks](cypress/components/callbacks) | Listen for messages dispatched from the component
 [global-handlers](cypress/components/global-handlers) | Attaches event listeners to `document` and `window`
 [hello](cypress/components/hello) | Hello, component testing!
 [image](cypress/components/image) | Loading Rick-Roll image

--- a/cypress/components/callbacks/Inner.svelte
+++ b/cypress/components/callbacks/Inner.svelte
@@ -1,0 +1,15 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+
+	function sayHello() {
+		dispatch('inner-message', {
+			text: 'Hello!'
+		});
+	}
+</script>
+
+<button on:click={sayHello}>
+	Click to say hello
+</button>

--- a/cypress/components/callbacks/README.md
+++ b/cypress/components/callbacks/README.md
@@ -1,0 +1,18 @@
+Examples from https://fireship.io/lessons/svelte-v3-overview-firebase/
+
+Shows how to listen for messages from the component via callbacks.
+
+```js
+mount(TodoItem, {
+  props: {
+    id: 'todo-id',
+    text: 'write a test',
+    complete: false,
+  },
+  callbacks: {
+    remove: cy.stub().as('remove'),
+    toggle: cy.stub().as('toggle'),
+    'inner-message': cy.stub().as('inner-message'),
+  },
+})
+```

--- a/cypress/components/callbacks/TodoItem.svelte
+++ b/cypress/components/callbacks/TodoItem.svelte
@@ -1,0 +1,42 @@
+<script>
+  import Inner from './Inner.svelte'
+  import { createEventDispatcher } from "svelte";
+  const dispatch = createEventDispatcher();
+  function remove() {
+    dispatch("remove", { id });
+  }
+  function toggleStatus() {
+    let newStatus = !complete;
+    dispatch("toggle", {
+      id,
+      newStatus
+    });
+  }
+
+  export let id; // document ID
+  export let text;
+  export let complete;
+</script>
+
+<style>
+  .is-complete {
+    text-decoration: line-through;
+    color: green;
+  }
+</style>
+
+<li>
+
+  {#if complete}
+    <span class="is-complete">{text}</span>
+    <button data-cy="toggle" on:click={toggleStatus}>✔️</button>
+  {:else}
+    <span>{text}</span>
+    <button data-cy="toggle" on:click={toggleStatus}>❌</button>
+  {/if}
+
+  <button data-cy="remove" on:click={remove}>🗑</button>
+
+  <!-- forward messages from the inner component -->
+  <Inner on:inner-message />
+</li>

--- a/cypress/components/callbacks/todo-item-spec.js
+++ b/cypress/components/callbacks/todo-item-spec.js
@@ -1,0 +1,47 @@
+/// <reference types="cypress" />
+import TodoItem from './TodoItem.svelte'
+import { mount } from 'cypress-svelte-unit-test'
+
+/* eslint-env mocha */
+describe('TodoItem with dispatch', () => {
+  it('receives messages from the component', () => {
+    mount(TodoItem, {
+      props: {
+        id: 'todo-id',
+        text: 'write a test',
+        complete: false,
+      },
+      callbacks: {
+        remove: cy.stub().as('remove'),
+        toggle: cy.stub().as('toggle'),
+        'inner-message': cy.stub().as('inner-message'),
+      },
+    })
+    cy.get('[data-cy=toggle]').click()
+    // check the message got back to our stub
+    cy.get('@toggle')
+      .should('be.called')
+      .its('firstCall.args.0.detail')
+      .should('deep.equal', {
+        id: 'todo-id',
+        newStatus: true,
+      })
+
+    cy.get('[data-cy=remove]').click()
+    cy.get('@remove')
+      .should('be.called')
+      .its('firstCall.args.0.detail')
+      .should('deep.equal', {
+        id: 'todo-id',
+      })
+
+    // check if messages from inner component are forwarded
+    cy.contains('Click to say hello').click()
+    cy.get('@inner-message')
+      .should('be.called')
+      .its('firstCall.args.0.detail')
+      .should('deep.equal', {
+        text: 'Hello!',
+      })
+  })
+})

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,9 +50,30 @@ export interface StyleOptions {
   html: string
 }
 
+export interface ComponentOptions {
+  callbacks?: {
+    [key: string]: Function
+  }
+}
+
+interface SvelteComponentOptions {
+  target: Element
+}
+interface SvelteComponent {
+  $$: {
+    callbacks: {
+      [key: string]: Function[]
+    }
+  }
+}
+
+interface SvelteComponentConstructor {
+  new (options: SvelteComponentOptions): SvelteComponent
+}
+
 export function mount(
-  Component: any,
-  options = {},
+  Component: SvelteComponentConstructor,
+  options: ComponentOptions = {},
   styleOptions: Partial<StyleOptions> = {},
 ) {
   checkMountModeEnabled()
@@ -94,6 +115,13 @@ export function mount(
     })
 
     const component = new Component(allOptions)
+    if (options.callbacks) {
+      // write message callbacks
+      Object.keys(options.callbacks).forEach((message) => {
+        component.$$.callbacks[message] = [options.callbacks![message]]
+      })
+    }
+
     return cy.wrap(component)
   })
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -76,6 +76,7 @@ export function mount(
   options: ComponentOptions = {},
   styleOptions: Partial<StyleOptions> = {},
 ) {
+  options = options || {}
   checkMountModeEnabled()
 
   return cy.then(() => {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist"
   ],
+  "types": "dist",
   "homepage": "https://github.com/bahmutov/cypress-svelte-unit-test#readme",
   "keywords": [
     "cypress",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "allowJs": false /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "dist" /* Redirect output structure to the directory. */,
@@ -25,8 +25,10 @@
     "strict": true /* Enable all strict type-checking options. */,
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "cypress-svelte-unit-test": ["cypress-svelte-unit-test"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     "types": [
@@ -44,7 +46,5 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "esModuleInterop": true
   },
-  "include": [
-    "lib/**/*.ts"
-  ]
+  "include": ["lib/**/*.ts"]
 }


### PR DESCRIPTION
```js
mount(TodoItem, {
  props: {
    id: 'todo-id',
    text: 'write a test',
    complete: false,
  },
  callbacks: {
    remove: cy.stub().as('remove'),
    toggle: cy.stub().as('toggle'),
    'inner-message': cy.stub().as('inner-message'),
  },
})
```