### PR TITLE
fix: select only body direct children when cleaning up the style

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -15,7 +15,7 @@ export function checkMountModeEnabled() {
  * left from any previous test
  */
 export function cleanupStyles(document: Document) {
-  const styles = document.body.querySelectorAll('style')
+  const styles = document.querySelectorAll('body > style')
   styles.forEach((styleElement) => {
     document.body.removeChild(styleElement)
   })


### PR DESCRIPTION
When cleaning up the styles, there is a scenario where it fails with the error:

> Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node

This basically happens when the component injects its own style tags.