### PR TITLE
Chore: Improve html template check

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -114,19 +114,19 @@ export function mount(
       document.getElementsByTagName('body')[0].prepend(el)
     }
     return injectStylesBeforeElement(styleOptions, document, el).then(() => {
-      // by default we mount the component into the created element
+      // by default, we mount the component into the created element
       let target = el
 
-      if (styleOptions && styleOptions.html) {
-        el.innerHTML = styleOptions.html
-        target = document.getElementById('here')
-        if (!target) {
-          console.error('mount has HTML with DIV with ID "here"')
-          console.error(styleOptions.html)
-          throw new Error(
-            'Could not find element with ID "here" in the HTML passed',
-          )
-        }
+      const wrapperHtml = styleOptions && typeof styleOptions.html === 'string' && styleOptions.html.trim() !== '' ? styleOptions.html : '<div id="here"></div>';
+
+      el.innerHTML = wrapperHtml;
+      target = document.getElementById('here')
+      if (!target) {
+        console.error('mount has HTML with DIV with ID "here"')
+        console.error(styleOptions.html)
+        throw new Error(
+          'Could not find element with ID "here" in the HTML passed',
+        )
       }
 
       const allOptions = Object.assign({}, options, {


### PR DESCRIPTION
This PR simplifies the logic around template usage.

It adds a more strict check to html property of styleOptions and disregards empty strings.

The check that disregards empty strings as a valid value can be discussed. I believe it adds to convenience to disregard empty strings as a value, but it can also be a bit misleading as not error will be shown warning about setting that to empty.

This fix came when I was testing my other PR: _Fix: properly destroy components after test case_ (#304)